### PR TITLE
Implements Rectify UV faces operation

### DIFF
--- a/op_rectify.py
+++ b/op_rectify.py
@@ -1,12 +1,12 @@
 import bmesh
 import bpy
-from mathutils import Vector
+from .services.rectify_service import align_uv_rectify
 
 
 class op(bpy.types.Operator):
     bl_idname = "uv.textools_rectify"
     bl_label = "Rectify"
-    bl_description = "Align selected UV faces or vertices to rectangular distribution"
+    bl_description = "Align selected UV faces to rectangular distribution (Quads only)"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
@@ -21,113 +21,13 @@ class op(bpy.types.Operator):
 
     def execute(self, context):
         obj = context.active_object
-        try:
-            area = next((a for a in context.screen.areas if a.type == 'IMAGE_EDITOR'), None)
-            if area:
-                with context.temp_override(area=area):
-                    bpy.ops.uv.select_split()
-            else:
-                bpy.ops.uv.select_split()
-        except Exception:
-            pass
-
         bm = bmesh.from_edit_mesh(obj.data)
         uv_layer = bm.loops.layers.uv.verify()
 
-        selected_faces = [f for f in bm.faces if f.select]
-        if not selected_faces:
-            self.report({'WARNING'}, "No faces selected.")
+        success = align_uv_rectify(obj, bm, uv_layer.name)
+
+        if not success:
+            self.report({'WARNING'}, "No quads selected or operation failed.")
             return {'CANCELLED'}
 
-        islands = self.get_connected_components(selected_faces)
-
-        if len(selected_faces) == len(bm.faces) and len(bm.faces) > 100:
-            pass
-
-        for island_faces in islands:
-            self.rectify_island(bm, uv_layer, island_faces)
-
-        bmesh.update_edit_mesh(obj.data)
-
-        try:
-            if area:
-                with context.temp_override(area=area):
-                    bpy.ops.uv.unwrap(method='CONFORMAL', margin=0)
-            else:
-                bpy.ops.uv.unwrap(method='CONFORMAL', margin=0)
-        except Exception:
-            pass
-
         return {'FINISHED'}
-
-    def get_connected_components(self, faces):
-        faces_set = set(faces)
-        islands = []
-        while faces_set:
-            seed = faces_set.pop()
-            island = {seed}
-            stack = [seed]
-            while stack:
-                f = stack.pop()
-                for edge in f.edges:
-                    for link_face in edge.link_faces:
-                        if link_face in faces_set:
-                            island.add(link_face)
-                            faces_set.remove(link_face)
-                            stack.append(link_face)
-            islands.append(list(island))
-        return islands
-
-    def rectify_island(self, bm, uv_layer, faces):
-        face_set = set(faces)
-        boundary_loops = []
-        internal_loops = []
-
-        for f in faces:
-            for loop in f.loops:
-                edge = loop.edge
-                shared_selected_count = sum(1 for lf in edge.link_faces if lf in face_set)
-
-                if shared_selected_count == 1:
-                    boundary_loops.append(loop)
-                else:
-                    internal_loops.append(loop)
-
-        if not boundary_loops: return
-
-        for l in internal_loops:
-            l[uv_layer].pin_uv = False
-
-        coords = [l[uv_layer].uv for l in boundary_loops]
-        min_x = min(c.x for c in coords)
-        max_x = max(c.x for c in coords)
-        min_y = min(c.y for c in coords)
-        max_y = max(c.y for c in coords)
-
-        width = max_x - min_x
-        height = max_y - min_y
-
-        if width < 1e-5: width = 1.0
-        if height < 1e-5: height = 1.0
-
-        for loop in boundary_loops:
-            uv = loop[uv_layer].uv
-
-            rel_x = (uv.x - min_x) / width
-            rel_y = (uv.y - min_y) / height
-
-            new_x, new_y = uv.x, uv.y
-            threshold = 0.49
-
-            if rel_x < threshold:
-                new_x = min_x
-            elif rel_x > (1.0 - threshold):
-                new_x = max_x
-
-            if rel_y < threshold:
-                new_y = min_y
-            elif rel_y > (1.0 - threshold):
-                new_y = max_y
-
-            loop[uv_layer].uv = Vector((new_x, new_y))
-            loop[uv_layer].pin_uv = True

--- a/services/rectify_service.py
+++ b/services/rectify_service.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import bmesh
+import bpy
+from bmesh.types import BMesh
+from bpy.types import Object
+
+
+def align_uv_rectify(obj: Object, bm: BMesh, uv_layer_name: str):
+    """
+    Rectify logic as a wrapper for Blender's native 'follow_active_quads'.
+
+    NOTE: Only processes Quads. Triangles and N-gons are explicitly excluded
+    to prevent UV layout distortion during normalization.
+    """
+    mesh_data = obj.data
+    uv_layer = bm.loops.layers.uv.get(uv_layer_name)
+    if uv_layer is None:
+        print(f"Error: UV layer '{uv_layer_name}' not found.")
+        return False
+
+    all_selected = [f for f in bm.faces if f.select]
+    target_faces = [f for f in all_selected if len(f.verts) == 4]
+
+    if not target_faces:
+        return False
+
+    active_face = bm.faces.active
+
+    if not active_face or active_face not in target_faces:
+        active_face = target_faces[0]
+        bm.faces.active = active_face
+
+    loops = active_face.loops
+    loops[0][uv_layer].uv = (0, 0)
+    loops[1][uv_layer].uv = (1, 0)
+    loops[2][uv_layer].uv = (1, 1)
+    loops[3][uv_layer].uv = (0, 1)
+
+    bmesh.update_edit_mesh(mesh_data)
+
+    try:
+        bpy.ops.uv.follow_active_quads(mode="EVEN")
+    except RuntimeError:
+        return False
+
+    returned_bmesh: BMesh = bmesh.from_edit_mesh(mesh_data)
+    uv_layer = returned_bmesh.loops.layers.uv.get(uv_layer_name)
+
+    selected_faces = [f for f in returned_bmesh.faces if f.select and len(f.verts) == 4]
+
+    if not selected_faces:
+        return True
+
+    min_x, max_x = float("inf"), float("-inf")
+    min_y, max_y = float("inf"), float("-inf")
+
+    has_verts = False
+    for face in selected_faces:
+        for loop in face.loops:
+            u, v = loop[uv_layer].uv
+            if u < min_x:
+                min_x = u
+            if u > max_x:
+                max_x = u
+            if v < min_y:
+                min_y = v
+            if v > max_y:
+                max_y = v
+            has_verts = True
+
+    if not has_verts:
+        return True
+
+    width = max_x - min_x
+    height = max_y - min_y
+    if width == 0:
+        width = 1
+    if height == 0:
+        height = 1
+
+    for face in selected_faces:
+        for loop in face.loops:
+            u, v = loop[uv_layer].uv
+            loop[uv_layer].uv = ((u - min_x) / width, (v - min_y) / height)
+
+    bmesh.update_edit_mesh(mesh_data)
+    return True


### PR DESCRIPTION
Introduces a new operator that rectifies selected UV faces, aligning them to a rectangular distribution.

This commit extracts the rectification logic into a dedicated service for better code organization and reusability. The operator now leverages Blender's 'follow_active_quads' function to achieve the rectification.

It also constrains the operation to quads only, avoiding distortion on tris or n-gons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined UV rectification from island-based approach to service-driven implementation
  * Operator now exclusively handles quad face alignment

* **New Features**
  * Automatic failure detection with user warnings and operation cancellation
  * Enhanced validation for edge cases in UV dimensions and selections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->